### PR TITLE
Clear cache command

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -3,6 +3,7 @@
 namespace Petebishwhip\NativePhpCli;
 
 use Petebishwhip\NativePhpCli\Command\CheckNativePHPUpdatesCommand;
+use Petebishwhip\NativePhpCli\Command\ClearCacheCommand;
 use Petebishwhip\NativePhpCli\Command\UpdateNativePHPCommand;
 
 class Application extends \Symfony\Component\Console\Application
@@ -25,6 +26,7 @@ class Application extends \Symfony\Component\Console\Application
            new Command\NewCommand(),
            new UpdateNativePHPCommand(),
            new CheckNativePHPUpdatesCommand(),
+           new ClearCacheCommand(),
        ];
     }
 }

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -51,6 +51,15 @@ class Cache
             })
             ->map(function ($file) {
                 return str_replace('_cache.json', '', $file);
-            });
+            })->values();
+    }
+
+    public function clearAllCaches(): void
+    {
+        $caches = $this->getAllAvailableCaches();
+
+        $caches->each(function ($cache) {
+            $this->removeCache($cache);
+        });
     }
 }

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Petebishwhip\NativePhpCli;
+
+use Illuminate\Support\Collection;
+
+class Cache
+{
+    public const CACHE_DIR = __DIR__ . '/../cache';
+    public const CACHE_FILENAME_FORMAT = '%s_cache.json';
+
+    public function cacheExists(string $cache): bool
+    {
+        return file_exists(self::CACHE_DIR . '/' . $this->getCacheFileName($cache));
+    }
+
+    private function getCacheFileName(string $key): string
+    {
+        return sprintf(self::CACHE_FILENAME_FORMAT, $key);
+    }
+
+    public function retrieveCache(string $key): ?Collection
+    {
+        $cacheFile = self::CACHE_DIR . '/' . $this->getCacheFileName($key);
+
+        if (!$this->cacheExists($key)) {
+            return null;
+        }
+
+        return collect(json_decode(file_get_contents($cacheFile), true));
+    }
+
+    public function removeCache(string $key): bool
+    {
+        $cacheFile = self::CACHE_DIR . '/' . $this->getCacheFileName($key);
+
+        if ($this->cacheExists($key)) {
+            return unlink($cacheFile);
+        }
+
+        return false;
+    }
+
+    public function getAllAvailableCaches(): Collection
+    {
+        $cacheFiles = scandir(self::CACHE_DIR);
+
+        return collect($cacheFiles)
+            ->filter(function ($file) {
+                return $file !== '.' && $file !== '..' && $file !== '.gitkeep';
+            })
+            ->map(function ($file) {
+                return str_replace('_cache.json', '', $file);
+            });
+    }
+}

--- a/src/Command/ClearCacheCommand.php
+++ b/src/Command/ClearCacheCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Petebishwhip\NativePhpCli\Command;
+
+use Illuminate\Console\QuestionHelper;
+use Petebishwhip\NativePhpCli\Cache;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+#[AsCommand(
+    name: 'cache:clear',
+    description: 'Clear the application cache'
+)]
+class ClearCacheCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->addOption(
+            'cache',
+            'c',
+            InputOption::VALUE_OPTIONAL,
+            'The cache to clear. Default: all',
+            'all'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $cache = new Cache();
+        $cacheKey = strtolower(trim($input->getOption('cache')));
+
+        /** @var QuestionHelper $questionHelper */
+        $questionHelper = $this->getHelper('question');
+
+        $question = new ConfirmationQuestion(
+            $cacheKey === 'all'
+                ? 'Are you sure you want to clear all caches?'
+                : 'Are you sure you want to clear the ' . $cacheKey . ' cache? [Y/n]',
+            true
+        );
+
+        if (!$questionHelper->ask($input, $output, $question)) {
+            $output->writeln('<error>Cache clear cancelled by user.</error>');
+
+            return Command::FAILURE;
+        }
+
+        if ($cacheKey === 'all') {
+            $output->writeln('Clearing all caches');
+
+            $caches = $cache->getAllAvailableCaches();
+
+            if ($caches->isEmpty()) {
+                $output->writeln('<info>No caches to clear</info>');
+
+                return Command::SUCCESS;
+            }
+
+            $caches->each(function ($cacheName) use ($cache, $output) {
+                $output->writeln("Clearing cache: $cacheName");
+
+                if ($cache->removeCache($cacheName)) {
+                    $output->writeln("<info>Cache $cacheName cleared!</info>");
+                } else {
+                    $output->writeln("<error>Failed to clear $cacheName cache</error>");
+                }
+            });
+        } else {
+            if (!$cache->cacheExists($cacheKey)) {
+                $output->writeln("<error>Cache $cacheKey does not exist</error>");
+
+                return Command::FAILURE;
+            }
+
+            $output->writeln("Clearing $cacheKey cache");
+
+            if ($cache->removeCache($cacheKey)) {
+                $output->writeln("<info>Cache $cacheKey cleared!</info>");
+            } else {
+                $output->writeln("<error>Failed to clear $cacheKey cache</error>");
+            }
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Petebishwhip\NativePhpCli\Tests;
+
+use Petebishwhip\NativePhpCli\Cache;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\TestCase;
+
+class CacheTest extends TestCase
+{
+    public function testCacheExistsCommand()
+    {
+        // Place a file in the cache directory - key: test
+        touch(ROOT_DIR . '/cache/test_cache.json');
+
+        $cache = new Cache();
+
+        // TEST: cacheExists returns false when a file does not exist
+        $this->assertFalse($cache->cacheExists('non_existent'));
+
+        // TEST: cacheExists returns true when a file exists
+        $this->assertTrue($cache->cacheExists('test'));
+
+        // CLEANUP: Remove the test cache file
+        unlink(ROOT_DIR . '/cache/test_cache.json');
+    }
+
+    public function testRetrieveCacheCommand()
+    {
+        // Place a file in the cache directory - key: test
+        file_put_contents(ROOT_DIR . '/cache/test_cache.json', json_encode(['test' => 'data']));
+
+        $cache = new Cache();
+
+        // TEST: retrieveCache returns null when a file does not exist
+        $this->assertNull($cache->retrieveCache('non_existent'));
+
+        // TEST: retrieveCache returns the contents of the cache file
+        $this->assertEquals(['test' => 'data'], $cache->retrieveCache('test')->toArray());
+
+        // CLEANUP: Remove the test cache file
+        unlink(ROOT_DIR . '/cache/test_cache.json');
+    }
+
+    public function testRemoveCacheCommand()
+    {
+        // Place a file in the cache directory - key: test
+        touch(ROOT_DIR . '/cache/test_cache.json');
+
+        $cache = new Cache();
+
+        // TEST: removeCache returns false when a file does not exist
+        $this->assertFalse($cache->removeCache('non_existent'));
+
+        // TEST: removeCache returns true when a file exists
+        $this->assertTrue($cache->removeCache('test'));
+
+        // TEST: The cache file has been removed
+        $this->assertFalse(file_exists(ROOT_DIR . '/cache/test_cache.json'));
+    }
+
+    public function testGetAllAvailableCachesCommand()
+    {
+        $cache = new Cache();
+
+        // TEST: getAllAvailableCaches returns an empty collection when no cache files exist
+        $this->assertEquals([], $cache->getAllAvailableCaches()->toArray());
+
+        // Place a file in the cache directory - key: test
+        touch(ROOT_DIR . '/cache/test_cache.json');
+
+        // TEST: getAllAvailableCaches returns a collection of cache keys
+        $this->assertEquals(['test'], $cache->getAllAvailableCaches()->toArray());
+
+        // CLEANUP: Remove the test cache file
+        unlink(ROOT_DIR . '/cache/test_cache.json');
+    }
+
+    /**
+     * @return void
+     */
+    #[Depends('testGetAllAvailableCachesCommand')]
+    public function testClearAllCachesCommand()
+    {
+        // Place a file in the cache directory - key: test{1,2,3}
+        touch(ROOT_DIR . '/cache/test1_cache.json');
+        touch(ROOT_DIR . '/cache/test2_cache.json');
+        touch(ROOT_DIR . '/cache/test3_cache.json');
+
+        $cache = new Cache();
+
+        // TEST: clearAllCaches removes all cache files
+        $cache->clearAllCaches();
+
+        // TEST: The cache directory is empty
+        $this->assertEquals([], $cache->getAllAvailableCaches()->toArray());
+    }
+}


### PR DESCRIPTION
Closes https://github.com/PeteBishwhip/native-cli/issues/11

- Implements cache:clear command
- Use -c {cache} for a specific cache (e.g. version)
- Use -n for non-interactive